### PR TITLE
Fix parsing of HTTP headers, broken communication with Java client.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 **/*.rs.bk
 Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ codecov = {repository = "sile/rustracing_jaeger"}
 
 [dependencies]
 hostname = "0.1"
+percent-encoding = "1.0"
 rand = "0.6"
 rustracing = "0.1.8"
 thrift_codec = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 #![warn(missing_docs)]
 #[macro_use]
 extern crate trackable;
+extern crate percent_encoding;
 
 pub use self::span::Span;
 pub use self::tracer::Tracer;


### PR DESCRIPTION
- Official Java client `io.jaegertracing:jaeger-client:0.33.1` sends HTTP header `uber-trace-id` with url-encoding, but rusttracing_jaeager doesn't expect delimiter `%3A` ~ `:`.
- Java & tcpdump: `fd4b7d915e6b3daa%3A5d7d76abb1a28915%3Afd4b7d915e6b3daa%3A1`
- rusttracing_jaeager expects: `fd4b7d915e6b3daa:5d7d76abb1a28915:fd4b7d915e6b3daa:1`
- Unfortunately this is not defined in the protocol at https://www.jaegertracing.io/docs/1.10/client-libraries/ so it's probably implementation specific.
- It isn't defined for opentracing as well - "(The specifics of the encoding is left to the implementor, so you won’t have to worry about that.)", https://opentracing.io/docs/best-practices/instrumenting-frameworks/#extract-the-current-trace-state
- `JAEGER_BAGGAGE_HEADER` was incorrectly used instead of `JAEGER_DEBUG_HEADER` when parsing debug ID.