### PR TITLE
Use `crossbeam_channel` to remove mutex from `Mutex<Tracer>`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,7 @@ crossbeam-channel = "0.3"
 hostname = "0.1"
 percent-encoding = "1.0"
 rand = "0.6"
-# TODO: Temporary for integration
-#rustracing = "0.1.8"
-rustracing = { git = "https://github.com/mixalturek/rustracing.git", branch="no-mutex" }
+rustracing = "0.2.0"
 thrift_codec = "0.1"
 trackable = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,13 @@ travis-ci = {repository = "sile/rustracing_jaeger"}
 codecov = {repository = "sile/rustracing_jaeger"}
 
 [dependencies]
+crossbeam-channel = "0.3"
 hostname = "0.1"
 percent-encoding = "1.0"
 rand = "0.6"
-rustracing = "0.1.8"
+# TODO: Temporary for integration
+#rustracing = "0.1.8"
+rustracing = { git = "https://github.com/mixalturek/rustracing.git", branch="no-mutex" }
 thrift_codec = "0.1"
 trackable = "0.2"
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ use rustracing_jaeger::Tracer;
 use rustracing_jaeger::reporter::JaegerCompactReporter;
 
 // Creates a tracer
-let (tracer, span_rx) = Tracer::new(AllSampler);
+let (span_tx, span_rx) = crossbeam_channel::bounded(10);
+let tracer = Tracer::new(AllSampler, span_tx);
 {
     let span = tracer.span("sample_op").start();
     // Do something

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ use rustracing_jaeger::reporter::JaegerCompactReporter;
 
 // Creates a tracer
 let (span_tx, span_rx) = crossbeam_channel::bounded(10);
-let tracer = Tracer::new(AllSampler, span_tx);
+let tracer = Tracer::with_sender(AllSampler, span_tx);
 {
     let span = tracer.span("sample_op").start();
     // Do something

--- a/examples/http_hello_server.rs
+++ b/examples/http_hello_server.rs
@@ -46,7 +46,7 @@ impl HandleRequest for Hello {
 
 fn main() -> trackable::result::MainResult {
     let (span_tx, span_rx) = crossbeam_channel::bounded(100);
-    let tracer = Tracer::new(AllSampler, span_tx);
+    let tracer = Tracer::with_sender(AllSampler, span_tx);
     let handler = Hello { tracer };
     std::thread::spawn(move || {
         let reporter = track_try_unwrap!(JaegerCompactReporter::new("http_hello_server"));

--- a/examples/http_hello_server.rs
+++ b/examples/http_hello_server.rs
@@ -12,10 +12,9 @@ use rustracing_jaeger::reporter::JaegerCompactReporter;
 use rustracing_jaeger::span::SpanContext;
 use rustracing_jaeger::Tracer;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 
 struct Hello {
-    tracer: Arc<Mutex<Tracer>>,
+    tracer: Tracer,
 }
 impl HandleRequest for Hello {
     const METHOD: &'static str = "GET";
@@ -35,8 +34,8 @@ impl HandleRequest for Hello {
         }
 
         let context = track_try_unwrap!(SpanContext::extract_from_http_header(&carrier));
-        let tracer = self.tracer.lock().expect("Cannot acquire lock");
-        let _span = tracer
+        let _span = self
+            .tracer
             .span("Hello::handle_request")
             .child_of(&context)
             .start();
@@ -46,10 +45,9 @@ impl HandleRequest for Hello {
 }
 
 fn main() -> trackable::result::MainResult {
-    let (tracer, span_rx) = Tracer::new(AllSampler);
-    let handler = Hello {
-        tracer: Arc::new(Mutex::new(tracer)),
-    };
+    let (span_tx, span_rx) = crossbeam_channel::bounded(100);
+    let tracer = Tracer::new(AllSampler, span_tx);
+    let handler = Hello { tracer };
     std::thread::spawn(move || {
         let reporter = track_try_unwrap!(JaegerCompactReporter::new("http_hello_server"));
         for span in span_rx {

--- a/examples/report.rs
+++ b/examples/report.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 fn main() -> trackable::result::MainResult {
     let (span_tx, span_rx) = crossbeam_channel::bounded(10);
-    let tracer = Tracer::new(AllSampler, span_tx);
+    let tracer = Tracer::with_sender(AllSampler, span_tx);
     {
         let span0 = tracer.span("main").start();
         thread::sleep(Duration::from_millis(10));

--- a/examples/report.rs
+++ b/examples/report.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate trackable;
 
+use rustracing::sampler::AllSampler;
 use rustracing::tag::Tag;
 use rustracing_jaeger::reporter::JaegerCompactReporter;
 use rustracing_jaeger::Tracer;
@@ -8,7 +9,8 @@ use std::thread;
 use std::time::Duration;
 
 fn main() -> trackable::result::MainResult {
-    let (tracer, span_rx) = Tracer::new(rustracing::sampler::AllSampler);
+    let (span_tx, span_rx) = crossbeam_channel::bounded(10);
+    let tracer = Tracer::new(AllSampler, span_tx);
     {
         let span0 = tracer.span("main").start();
         thread::sleep(Duration::from_millis(10));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,8 @@
 //! use rustracing_jaeger::reporter::JaegerCompactReporter;
 //!
 //! // Creates a tracer
-//! let (tracer, span_rx) = Tracer::new(AllSampler);
+//! let (span_tx, span_rx) = crossbeam_channel::bounded(10);
+//! let tracer = Tracer::new(AllSampler, span_tx);
 //! {
 //!     let span = tracer.span("sample_op").start();
 //!     // Do something
@@ -51,7 +52,8 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let (tracer, span_rx) = Tracer::new(AllSampler);
+        let (span_tx, span_rx) = crossbeam_channel::bounded(10);
+        let tracer = Tracer::new(AllSampler, span_tx);
         {
             let _span = tracer.span("it_works").start();
             // do something

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! // Creates a tracer
 //! let (span_tx, span_rx) = crossbeam_channel::bounded(10);
-//! let tracer = Tracer::new(AllSampler, span_tx);
+//! let tracer = Tracer::with_sender(AllSampler, span_tx);
 //! {
 //!     let span = tracer.span("sample_op").start();
 //!     // Do something
@@ -53,7 +53,7 @@ mod tests {
     #[test]
     fn it_works() {
         let (span_tx, span_rx) = crossbeam_channel::bounded(10);
-        let tracer = Tracer::new(AllSampler, span_tx);
+        let tracer = Tracer::with_sender(AllSampler, span_tx);
         {
             let _span = tracer.span("it_works").start();
             // do something

--- a/src/span.rs
+++ b/src/span.rs
@@ -60,6 +60,8 @@ pub type FinishedSpan = rustracing::span::FinishedSpan<SpanContextState>;
 
 /// Span receiver.
 pub type SpanReceiver = rustracing::span::SpanReceiver<SpanContextState>;
+/// Sender of finished spans to the destination channel.
+pub type SpanSender = rustracing::span::SpanSender<SpanContextState>;
 
 /// Options for starting a span.
 pub type StartSpanOptions<'a> =
@@ -409,7 +411,8 @@ mod test {
 
     #[test]
     fn inject_to_text_map_works() -> TestResult {
-        let (tracer, _span_rx) = Tracer::new(AllSampler);
+        let (span_tx, _span_rx) = crossbeam_channel::bounded(10);
+        let tracer = Tracer::new(AllSampler, span_tx);
         let span = tracer.span("test").start();
         let context = track_assert_some!(span.context(), Failed);
 

--- a/src/span.rs
+++ b/src/span.rs
@@ -412,7 +412,7 @@ mod test {
     #[test]
     fn inject_to_text_map_works() -> TestResult {
         let (span_tx, _span_rx) = crossbeam_channel::bounded(10);
-        let tracer = Tracer::new(AllSampler, span_tx);
+        let tracer = Tracer::with_sender(AllSampler, span_tx);
         let span = tracer.span("test").start();
         let context = track_assert_some!(span.context(), Failed);
 


### PR DESCRIPTION
- SIGNIFICANT API CHANGE!
- https://github.com/sile/rustracing_jaeger/blob/master/examples/http_hello_server.rs#L18
- Fighting for a mutex on hot path may be expensive in a service that handles thousands requests/s.
- The mutex was introduced due to `std::sync::mpsc` channel. Yes, it can be cloned and passed to multiple threads but its technically impossible in a HTTP service where the threads are out of application's full control. It would lead to tracer inside thread locals which would be also nothing good.
- It's also better to build the channel outside the tracer and only pass the sender part inside. The application may choose between bounded and unbounded, configure max. queue size, etc.