### PR TITLE
This crate could be greater with more pub use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub use self::span::Span;
 pub use self::tracer::Tracer;
 pub use rustracing::{Error, ErrorKind, Result};
 pub use thrift::jaeger;
+pub use thrift::agent;
 
 pub mod reporter;
 pub mod span;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,15 +34,13 @@ extern crate trackable;
 pub use self::span::Span;
 pub use self::tracer::Tracer;
 pub use rustracing::{Error, ErrorKind, Result};
-pub use thrift::agent;
-pub use thrift::jaeger;
 
 pub mod reporter;
 pub mod span;
+pub mod thrift;
 
 mod constants;
 mod error;
-mod thrift;
 mod tracer;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ extern crate trackable;
 pub use self::span::Span;
 pub use self::tracer::Tracer;
 pub use rustracing::{Error, ErrorKind, Result};
+pub use thrift::jaeger;
 
 pub mod reporter;
 pub mod span;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub use rustracing::{Error, ErrorKind, Result};
 
 pub mod reporter;
 pub mod span;
+#[allow(missing_docs)]
 pub mod thrift;
 
 mod constants;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,8 @@ extern crate trackable;
 pub use self::span::Span;
 pub use self::tracer::Tracer;
 pub use rustracing::{Error, ErrorKind, Result};
-pub use thrift::jaeger;
 pub use thrift::agent;
+pub use thrift::jaeger;
 
 pub mod reporter;
 pub mod span;


### PR DESCRIPTION
I'm contributing to another repository and I found `thrift::jaeger` and `thrift::agent` is useful when I want to encode spans to bytes but not sending them.