### PR TITLE
Bind reporter to localhost as default.

### DIFF
--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -29,6 +29,8 @@ impl JaegerCompactReporter {
     /// Sets the address of the report destination agent to `addr`.
     ///
     /// The default address is `127.0.0.1:6831`.
+    ///
+    /// Note that you may also need to call `set_reporter_addr` if the `addr` is IPv6 or non localhost address.
     pub fn set_agent_addr(&mut self, addr: SocketAddr) {
         self.0.set_agent_addr(addr);
     }
@@ -83,6 +85,8 @@ impl JaegerBinaryReporter {
     /// Sets the address of the report destination agent to `addr`.
     ///
     /// The default address is `127.0.0.1:6832`.
+    ///
+    /// Note that you may also need to call `set_reporter_addr` if the `addr` is IPv6 or non localhost address.
     pub fn set_agent_addr(&mut self, addr: SocketAddr) {
         self.0.set_agent_addr(addr);
     }


### PR DESCRIPTION
Resolves #25 by binding the reporter (client) address to `127.0.0.1:0` as default.
To change the address, this PR introduces `Jaeger{Binary,Compact}Reporter::set_reporter_method`.