### PR TITLE
Update dependencies (trackable, rustracing and fibers_http_server) and edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crossbeam-channel = "0.5"
 hostname = "0.3.0"
 percent-encoding = "2.1.0"
 rand = "0.8.3"
-rustracing = "0.5.0"
+rustracing = "0.6"
 thrift_codec = "0.1.1"
 trackable = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/sile/rustracing_jaeger"
 readme = "README.md"
 keywords = ["opentracing", "jaeger"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [badges]
 coveralls = {repository = "sile/rustracing"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ percent-encoding = "2.1.0"
 rand = "0.8.3"
 rustracing = "0.5.0"
 thrift_codec = "0.1.1"
-trackable = "0.2.23"
+trackable = "1"
 
 [dev-dependencies]
 bytecodec = "0.4"
 fibers_global = "0.1"
-fibers_http_server = "0.1"
+fibers_http_server = "0.2"
 futures = "0.1"
 httpcodec = "0.2"

--- a/src/span.rs
+++ b/src/span.rs
@@ -393,11 +393,10 @@ where
     T: Write,
 {
     fn inject_to_binary(context: &SpanContext, carrier: &mut T) -> Result<()> {
-        let mut u64buf: [u8; 8];
-        let u32buf: [u8; 4];
-        let u8buf: [u8; 1];
+        let mut u64buf: [u8; 8] = context.state().trace_id.high.to_be_bytes();
+        let u32buf: [u8; 4] = [0; 4]; // TODO: Support baggage items
+        let u8buf: [u8; 1] = [context.state().flags as u8];
 
-        u64buf = context.state().trace_id.high.to_be_bytes();
         track!(carrier.write(&u64buf).map_err(error::from_io_error))?;
         u64buf = context.state().trace_id.low.to_be_bytes();
         track!(carrier.write(&u64buf).map_err(error::from_io_error))?;
@@ -406,10 +405,7 @@ where
         // parent_span_id attribute is obsolete, write zeros.
         u64buf = [0; 8];
         track!(carrier.write(&u64buf).map_err(error::from_io_error))?;
-        u8buf = [context.state().flags as u8];
         track!(carrier.write(&u8buf).map_err(error::from_io_error))?;
-        // TODO: Support baggage items
-        u32buf = [0; 4];
         track!(carrier.write(&u32buf).map_err(error::from_io_error))?;
 
         Ok(())


### PR DESCRIPTION
- trackable: 0.2 => 1.0
- rustracing: 0.5 => 0.6
- fibers_http_server (dev): 0.1 => 0.2
- Edition: 2018 => 2021